### PR TITLE
[fix] Linear scale axis label placement

### DIFF
--- a/src/scales/band.rs
+++ b/src/scales/band.rs
@@ -170,6 +170,10 @@ impl Scale<String> for ScaleBand {
         self.domain().clone()
     }
 
+    fn domain_max(&self) -> f32 {
+        0_f32
+    }
+
     /// Get the range value for the given domain entry.
     fn scale(&self, domain: &String) -> f32 {
         self.offsets[*self.index.get(domain).unwrap()]

--- a/src/scales/linear.rs
+++ b/src/scales/linear.rs
@@ -101,6 +101,11 @@ impl Scale<f32> for ScaleLinear {
         self.domain().clone()
     }
 
+    /// Get the domain max of the scale.
+    fn domain_max(&self) -> f32 {
+        self.domain[1]
+    }
+
     /// Get the range value for the given domain entry.
     fn scale(&self, domain: &f32) -> f32 {
         let a = self.domain[0];

--- a/src/scales/mod.rs
+++ b/src/scales/mod.rs
@@ -16,6 +16,8 @@ pub trait Scale<T> {
     /// Get the domain of the scale.
     fn get_domain(&self) -> Vec<T>;
 
+    fn domain_max(&self) -> f32;
+
     /// Get the range value for the given domain entry.
     fn scale(&self, domain: &T) -> f32;
 


### PR DESCRIPTION
Problem
The axis label placement y value is not correctly calculated and
right axis labels are overwriting the tick labels on the axis
Solution
* Ensure that max value of the scale is returned in the TickLabel enum
* Add two charaters of additional spacing to pad out from the numbers
Note